### PR TITLE
Disallow NaN in transactions

### DIFF
--- a/backend/src/api/student.ts
+++ b/backend/src/api/student.ts
@@ -33,6 +33,9 @@ router.post("/createTransaction", async (req, res) => {
     if (amountToDP.lte(0)) {
         return res.status(400).json({ message: "Amount must be positive" })
     }
+    if (!amountToDP.isFinite()) {
+        return res.status(400).json({ message: "Invalid Amount" })
+    }
 
     const transId = getRandom()
 


### PR DESCRIPTION
Creating a transaction with NaN will set the user's balance to NaN, giving them infinite money due to the following behaviours: NaN can be stored in the database
anything.lt(NaN) = false
NaN.lt(anything) = false